### PR TITLE
Parallelizes server initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,15 @@
 {
   "name": "@toolprint/hypertool-mcp",
-  "version": "0.0.32",
+  "version": "0.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@toolprint/hypertool-mcp",
-      "version": "0.0.32",
+      "version": "0.0.36",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.1",
-        "@seald-io/nedb": "^4.1.2",
         "@toolprint/mcp-logger": "^0.0.7",
         "@types/chalk": "^0.4.31",
         "@types/express": "^5.0.3",
@@ -2262,22 +2261,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@seald-io/binary-search-tree": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@seald-io/binary-search-tree/-/binary-search-tree-1.0.3.tgz",
-      "integrity": "sha512-qv3jnwoakeax2razYaMsGI/luWdliBLHTdC6jU55hQt1hcFqzauH/HsBollQ7IR4ySTtYhT+xyHoijpA16C+tA=="
-    },
-    "node_modules/@seald-io/nedb": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@seald-io/nedb/-/nedb-4.1.2.tgz",
-      "integrity": "sha512-bDr6TqjBVS2rDyYM9CPxAnotj5FuNL9NF8o7h7YyFXM7yruqT4ddr+PkSb2mJvvw991bqdftazkEo38gykvaww==",
-      "license": "MIT",
-      "dependencies": {
-        "@seald-io/binary-search-tree": "^1.0.3",
-        "localforage": "^1.10.0",
-        "util": "^0.12.5"
-      }
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
@@ -6392,12 +6375,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "license": "MIT"
-    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6674,24 +6651,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -6867,21 +6826,6 @@
         "call-bound": "^1.0.2",
         "has-symbols": "^1.1.0",
         "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7145,15 +7089,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -7162,15 +7097,6 @@
       "license": "MIT",
       "dependencies": {
         "uc.micro": "^2.0.0"
-      }
-    },
-    "node_modules/localforage": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -10801,19 +10727,6 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {

--- a/src/server/enhanced.ts
+++ b/src/server/enhanced.ts
@@ -547,7 +547,7 @@ export class EnhancedMetaMCPServer extends MetaMCPServer {
         logger.warn(`
 ⚠️  WARNING: No toolsets configured
 
-   Meta-MCP is running but no toolsets have been created yet.
+   ${APP_TECHNICAL_NAME} is running but no toolsets have been created yet.
    This means no underlying MCP server tools will be exposed.
 
    💡 Next steps:


### PR DESCRIPTION
### Summary
- Parallelizes server initialization.
- Deduplicate server names during connection manager initialization and emit errors for duplicates
- Log failed server initialization with `logger.error` to keep protocol output clean
- Add regression tests for server initialization failures and duplicate removal

### Testing
- `npx eslint src/connection/manager.ts src/connection/manager.test.ts`
- `npm run test:unit`
- `npm test` *(fails: Server not built & performance threshold exceeded)*
- `npm run test:integration` *(fails: stdio transport tests timed out)*

------
https://chatgpt.com/codex/tasks/task_b_689c021794488330940ca1ae1e4e2aee