### PR TITLE
feat: improve MCP config validation and CLI help system

### DIFF
--- a/src/config/mcpConfigParser.test.ts
+++ b/src/config/mcpConfigParser.test.ts
@@ -123,7 +123,7 @@ describe("MCPConfigParser", () => {
       });
     });
 
-    it("should require explicit type field and fail when missing", () => {
+    it("should default to stdio type when type field is missing (legacy behavior test)", () => {
       const content = JSON.stringify({
         mcpServers: {
           git: {
@@ -135,10 +135,13 @@ describe("MCPConfigParser", () => {
 
       const result = parser.parseContent(content);
 
-      expect(result.success).toBe(false);
-      expect(result.validationErrors).toContain(
-        'Server "git" is missing required "type" field. Must be "stdio", "http", or "sse"'
-      );
+      expect(result.success).toBe(true);
+      expect(result.config?.mcpServers.git).toMatchObject({
+        type: "stdio",
+        command: "uvx",
+        args: ["mcp-server-git"],
+        env: {},
+      });
     });
 
     it("should validate invalid server type", () => {
@@ -363,12 +366,10 @@ describe("MCPConfigParser", () => {
       const result = parser.parseContent(content);
 
       expect(result.success).toBe(false);
-      expect(result.config?.mcpServers.missingType).toBeUndefined();
+      expect(result.config?.mcpServers.missingType).toBeDefined(); // Should now be defined with defaulted type
       expect(result.config?.mcpServers.invalidStdio).toBeUndefined();
       expect(result.config?.mcpServers.validSse).toBeDefined();
-      expect(result.validationErrors).toContain(
-        'Server "missingType" is missing required "type" field. Must be "stdio", "http", or "sse"'
-      );
+      // missingType should now be valid with defaulted type
       expect(result.validationErrors).toContain(
         'Stdio server "invalidStdio" must have a "command" string'
       );
@@ -593,6 +594,464 @@ describe("MCPConfigParser", () => {
         type: "stdio",
         command: "./bin/sse-server",
       });
+    });
+  });
+
+  describe("optional type field with stdio default", () => {
+    it("should default to stdio type when type field is missing", () => {
+      const content = JSON.stringify({
+        mcpServers: {
+          git: {
+            command: "uvx",
+            args: ["mcp-server-git"],
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(true);
+      expect(result.config).toBeDefined();
+      expect(result.config?.mcpServers.git).toMatchObject({
+        type: "stdio",
+        command: "uvx",
+        args: ["mcp-server-git"],
+        env: {},
+      });
+    });
+
+    it("should default to stdio type when type field is undefined", () => {
+      const content = JSON.stringify({
+        mcpServers: {
+          docker: {
+            type: undefined,
+            command: "docker-mcp",
+            args: ["--port", "8080"],
+            env: { DOCKER_HOST: "unix:///var/run/docker.sock" },
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(true);
+      expect(result.config?.mcpServers.docker).toMatchObject({
+        type: "stdio",
+        command: "docker-mcp",
+        args: ["--port", "8080"],
+        env: { DOCKER_HOST: "unix:///var/run/docker.sock" },
+      });
+    });
+
+    it("should default to stdio type when type field is null", () => {
+      const content = JSON.stringify({
+        mcpServers: {
+          filesystem: {
+            type: null,
+            command: "mcp-server-filesystem",
+            args: ["/home/user/projects"],
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(true);
+      expect(result.config?.mcpServers.filesystem).toMatchObject({
+        type: "stdio",
+        command: "mcp-server-filesystem",
+        args: ["/home/user/projects"],
+        env: {},
+      });
+    });
+
+    it("should default to stdio type when type field is empty string", () => {
+      const content = JSON.stringify({
+        mcpServers: {
+          calculator: {
+            type: "",
+            command: "python",
+            args: ["-m", "calculator_mcp"],
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(true);
+      expect(result.config?.mcpServers.calculator).toMatchObject({
+        type: "stdio",
+        command: "python",
+        args: ["-m", "calculator_mcp"],
+        env: {},
+      });
+    });
+
+    it("should handle multiple servers with missing type fields", () => {
+      const content = JSON.stringify({
+        mcpServers: {
+          git: {
+            command: "uvx",
+            args: ["mcp-server-git"],
+          },
+          docker: {
+            command: "uvx",
+            args: ["mcp-server-docker"],
+            env: { DOCKER_HOST: "unix:///var/run/docker.sock" },
+          },
+          api: {
+            type: "sse",
+            url: "https://api.example.com/sse",
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(true);
+      expect(result.config).toBeDefined();
+      expect(Object.keys(result.config!.mcpServers)).toHaveLength(3);
+      expect(result.config?.mcpServers.git).toMatchObject({
+        type: "stdio",
+        command: "uvx",
+        args: ["mcp-server-git"],
+        env: {},
+      });
+      expect(result.config?.mcpServers.docker).toMatchObject({
+        type: "stdio",
+        command: "uvx",
+        args: ["mcp-server-docker"],
+        env: { DOCKER_HOST: "unix:///var/run/docker.sock" },
+      });
+      expect(result.config?.mcpServers.api).toMatchObject({
+        type: "sse",
+        url: "https://api.example.com/sse",
+        headers: {},
+        env: {},
+      });
+    });
+
+    it("should still validate stdio requirements when type is defaulted", () => {
+      const content = JSON.stringify({
+        mcpServers: {
+          missingCommand: {
+            // Missing command - should fail validation
+            args: ["--verbose"],
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(false);
+      expect(result.validationErrors).toContain(
+        'Stdio server "missingCommand" must have a "command" string'
+      );
+    });
+
+    it("should validate args array when type is defaulted", () => {
+      const content = JSON.stringify({
+        mcpServers: {
+          invalidArgs: {
+            command: "uvx",
+            args: "not-an-array",
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(false);
+      expect(result.validationErrors).toContain(
+        'Stdio server "invalidArgs" args must be an array'
+      );
+    });
+
+    it("should validate args items are strings when type is defaulted", () => {
+      const content = JSON.stringify({
+        mcpServers: {
+          mixedArgs: {
+            command: "python",
+            args: ["-m", "server", 123, true, null],
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(false);
+      expect(result.validationErrors).toContain(
+        'Stdio server "mixedArgs" args[2] must be a string'
+      );
+      expect(result.validationErrors).toContain(
+        'Stdio server "mixedArgs" args[3] must be a string'
+      );
+      expect(result.validationErrors).toContain(
+        'Stdio server "mixedArgs" args[4] must be a string'
+      );
+    });
+  });
+
+  describe("graceful handling of individual config failures", () => {
+    it("should continue processing valid configs when one has missing type and invalid command", () => {
+      const parser = new MCPConfigParser({ strict: false });
+      const content = JSON.stringify({
+        mcpServers: {
+          validServer: {
+            type: "stdio",
+            command: "uvx",
+            args: ["mcp-server-git"],
+          },
+          invalidServer: {
+            // Missing type (should default to stdio) but also missing command
+            args: ["--verbose"],
+          },
+          anotherValidServer: {
+            type: "sse",
+            url: "https://example.com/sse",
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(false);
+      expect(result.config?.mcpServers.validServer).toBeDefined();
+      expect(result.config?.mcpServers.anotherValidServer).toBeDefined();
+      expect(result.config?.mcpServers.invalidServer).toBeUndefined();
+      expect(result.validationErrors).toContain(
+        'Stdio server "invalidServer" must have a "command" string'
+      );
+      expect(Object.keys(result.config!.mcpServers)).toHaveLength(2);
+    });
+
+    it("should handle mix of missing types and explicit types with errors", () => {
+      const parser = new MCPConfigParser({ strict: false });
+      const content = JSON.stringify({
+        mcpServers: {
+          noTypeValid: {
+            // Should default to stdio and be valid
+            command: "uvx",
+            args: ["mcp-server-1"],
+          },
+          noTypeInvalid: {
+            // Should default to stdio but missing command
+            args: ["--config", "path"],
+          },
+          explicitStdioInvalid: {
+            type: "stdio",
+            // Missing command
+          },
+          explicitSseInvalid: {
+            type: "sse",
+            // Missing URL
+          },
+          explicitSseValid: {
+            type: "sse",
+            url: "https://api.example.com/sse",
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(false);
+      expect(result.config?.mcpServers.noTypeValid).toBeDefined();
+      expect(result.config?.mcpServers.explicitSseValid).toBeDefined();
+      expect(result.config?.mcpServers.noTypeInvalid).toBeUndefined();
+      expect(result.config?.mcpServers.explicitStdioInvalid).toBeUndefined();
+      expect(result.config?.mcpServers.explicitSseInvalid).toBeUndefined();
+
+      expect(result.validationErrors).toContain(
+        'Stdio server "noTypeInvalid" must have a "command" string'
+      );
+      expect(result.validationErrors).toContain(
+        'Stdio server "explicitStdioInvalid" must have a "command" string'
+      );
+      expect(result.validationErrors).toContain(
+        'SSE server "explicitSseInvalid" must have a "url" string'
+      );
+      expect(Object.keys(result.config!.mcpServers)).toHaveLength(2);
+    });
+
+    it("should log warnings for invalid configs in non-strict mode", () => {
+      const parser = new MCPConfigParser({ strict: false });
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const content = JSON.stringify({
+        mcpServers: {
+          valid: {
+            command: "uvx",
+            args: ["mcp-server"],
+          },
+          invalid: {
+            // Missing command, should default to stdio but fail validation
+            args: ["--verbose"],
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(false);
+      expect(result.config?.mcpServers.valid).toBeDefined();
+      expect(result.config?.mcpServers.invalid).toBeUndefined();
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should still fail completely in strict mode even with default type", () => {
+      const parser = new MCPConfigParser({ strict: true });
+      const content = JSON.stringify({
+        mcpServers: {
+          valid: {
+            command: "uvx",
+            args: ["mcp-server"],
+          },
+          invalid: {
+            // Missing command, should default to stdio but fail validation
+            args: ["--verbose"],
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(false);
+      expect(result.config).toBeUndefined();
+      expect(result.validationErrors).toContain(
+        'Stdio server "invalid" must have a "command" string'
+      );
+    });
+
+    it("should preserve env and other fields when type is defaulted", () => {
+      const content = JSON.stringify({
+        mcpServers: {
+          withEnv: {
+            // Type omitted, should default to stdio
+            command: "python",
+            args: ["-m", "myserver"],
+            env: {
+              PYTHONPATH: "/custom/path",
+              DEBUG: "true",
+            },
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(true);
+      expect(result.config?.mcpServers.withEnv).toMatchObject({
+        type: "stdio",
+        command: "python",
+        args: ["-m", "myserver"],
+        env: {
+          PYTHONPATH: "/custom/path",
+          DEBUG: "true",
+        },
+      });
+    });
+
+    it("should handle empty mcpServers object gracefully", () => {
+      const content = JSON.stringify({
+        mcpServers: {},
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(true);
+      expect(result.config).toEqual({
+        mcpServers: {},
+      });
+    });
+
+    it("should handle whitespace-only type values as empty", () => {
+      const content = JSON.stringify({
+        mcpServers: {
+          whitespaceType: {
+            type: "   ",
+            command: "uvx",
+            args: ["mcp-server"],
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(true);
+      expect(result.config?.mcpServers.whitespaceType).toMatchObject({
+        type: "stdio",
+        command: "uvx",
+        args: ["mcp-server"],
+        env: {},
+      });
+    });
+
+    it("should handle multiple servers with various type field issues", () => {
+      const parser = new MCPConfigParser({ strict: false });
+      const content = JSON.stringify({
+        mcpServers: {
+          missing: {
+            command: "uvx",
+            args: ["mcp-1"],
+          },
+          empty: {
+            type: "",
+            command: "uvx",
+            args: ["mcp-2"],
+          },
+          whitespace: {
+            type: "  \t  ",
+            command: "uvx",
+            args: ["mcp-3"],
+          },
+          nullType: {
+            type: null,
+            command: "uvx",
+            args: ["mcp-4"],
+          },
+          undefinedType: {
+            type: undefined,
+            command: "uvx",
+            args: ["mcp-5"],
+          },
+          explicit: {
+            type: "stdio",
+            command: "uvx",
+            args: ["mcp-6"],
+          },
+          invalidButMissingCommand: {
+            // Should default to stdio but fail on missing command
+            args: ["--help"],
+          },
+        },
+      });
+
+      const result = parser.parseContent(content);
+
+      expect(result.success).toBe(false);
+      expect(Object.keys(result.config!.mcpServers)).toHaveLength(6);
+
+      // All should default to stdio type
+      expect(result.config?.mcpServers.missing?.type).toBe("stdio");
+      expect(result.config?.mcpServers.empty?.type).toBe("stdio");
+      expect(result.config?.mcpServers.whitespace?.type).toBe("stdio");
+      expect(result.config?.mcpServers.nullType?.type).toBe("stdio");
+      expect(result.config?.mcpServers.undefinedType?.type).toBe("stdio");
+      expect(result.config?.mcpServers.explicit?.type).toBe("stdio");
+
+      // The invalid one should not be included
+      expect(
+        result.config?.mcpServers.invalidButMissingCommand
+      ).toBeUndefined();
+
+      // Should have validation error for the missing command
+      expect(result.validationErrors).toContain(
+        'Stdio server "invalidButMissingCommand" must have a "command" string'
+      );
     });
   });
 });

--- a/src/config/mcpConfigParser.ts
+++ b/src/config/mcpConfigParser.ts
@@ -169,31 +169,37 @@ export class MCPConfigParser {
       return { errors };
     }
 
-    // Require explicit type field for clarity
-    if (!config.type) {
-      errors.push(
-        `Server "${name}" is missing required "type" field. Must be "stdio", "http", or "sse"`
-      );
-      return { errors };
+    // Default to stdio type if type field is missing, null, undefined, or empty
+    let serverType = config.type;
+    if (
+      !serverType ||
+      serverType === null ||
+      serverType === undefined ||
+      (typeof serverType === "string" && serverType.trim() === "")
+    ) {
+      serverType = "stdio";
     }
 
     if (
-      config.type !== "stdio" &&
-      config.type !== "http" &&
-      config.type !== "sse"
+      serverType !== "stdio" &&
+      serverType !== "http" &&
+      serverType !== "sse"
     ) {
       errors.push(
-        `Server "${name}" has invalid type "${config.type}". Must be "stdio", "http", or "sse"`
+        `Server "${name}" has invalid type "${serverType}". Must be "stdio", "http", or "sse"`
       );
       return { errors };
     }
 
-    if (config.type === "stdio") {
-      return this.parseStdioConfig(name, config, basePath);
-    } else if (config.type === "http") {
-      return this.parseHttpConfig(name, config);
+    // Create a normalized config object with the determined type
+    const normalizedConfig = { ...config, type: serverType };
+
+    if (serverType === "stdio") {
+      return this.parseStdioConfig(name, normalizedConfig, basePath);
+    } else if (serverType === "http") {
+      return this.parseHttpConfig(name, normalizedConfig);
     } else {
-      return this.parseSSEConfig(name, config);
+      return this.parseSSEConfig(name, normalizedConfig);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -439,29 +439,46 @@ async function parseCliArguments(): Promise<RuntimeOptions> {
 
   program
     .name(APP_TECHNICAL_NAME)
-    .description(theme.info(APP_DESCRIPTION))
-    .version(APP_VERSION)
-    .option(
-      "--dry-run",
-      theme.info("Show what would be done without making changes") +
-        theme.warning(" (only valid with --install)"),
-      false
+    .description(
+      theme.info(APP_DESCRIPTION) +
+        "\n" +
+        theme.label("Use MCP options directly for quick start (default mode)")
     )
-    .option(
-      "--install [app]",
-      theme.warning("⚠️  DEPRECATED: Use 'hypertool-mcp setup' instead\n") +
-        theme.info("Install and configure integrations (legacy support)\n") +
-        theme.label(
-          "Options: all (default), claude-desktop (cd), cursor, claude-code (cc)\n"
-        ) +
-        theme.muted("Examples:\n") +
-        theme.muted(
-          "  hypertool-mcp setup               # Modern setup (recommended)\n"
-        ) +
-        theme.muted(
-          "  hypertool-mcp --install           # Legacy install (deprecated)\n"
-        )
-    );
+    .version(APP_VERSION);
+
+  // Add deprecated options as hidden options (they work but don't show in help)
+  program
+    .option("--dry-run", "", false)
+    .option("--install [app]", "", undefined);
+
+  // Hide the deprecated options from help
+  const dryRunOption = program.options.find((opt) =>
+    opt.flags.includes("--dry-run")
+  );
+  const installOption = program.options.find((opt) =>
+    opt.flags.includes("--install")
+  );
+  if (dryRunOption) dryRunOption.hidden = true;
+  if (installOption) installOption.hidden = true;
+
+  // Add helpful examples section explaining MCP options can be used directly
+  program.addHelpText(
+    "after",
+    `
+${theme.label("MCP Server Options (can be used directly):")}
+  ${theme.info("--mcp-config <path>     Path to MCP configuration file (.mcp.json)")}
+  ${theme.info("--transport <type>      Transport protocol (http, stdio) (default: stdio)")}
+  ${theme.info("--port <number>         Port for HTTP transport")}
+  ${theme.info("--debug                 Enable debug mode")}
+  ${theme.info("--linked-app <app-id>   Link to application config (claude-desktop, cursor, claude-code)")}
+  ${theme.muted("... and other MCP options (see 'mcp run --help' for full list)")}
+
+${theme.label("Examples:")}
+  ${theme.muted("hypertool-mcp --mcp-config ./config.json")}
+  ${theme.muted("hypertool-mcp --mcp-config ./config.json --transport http --port 3000")}
+  ${theme.muted("hypertool-mcp --mcp-config ~/.config/mcp.json --debug")}
+  ${theme.muted("hypertool-mcp --linked-app claude-desktop")}`
+  );
 
   // Add config subcommands
   const { createConfigCommands } = await import(

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -10,7 +10,7 @@ export type ClientTransportType = "stdio" | "http" | "sse";
  * Base configuration for an MCP server
  */
 export interface BaseServerConfig {
-  type: ClientTransportType;
+  type?: ClientTransportType;
   env?: Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary
Two key usability improvements to make MCP configuration and CLI more user-friendly:

### 1. Optional 'type' field with stdio default
- **Problem**: Config validation required explicit `type` field, failing when missing
- **Solution**: Make `type` field optional, defaulting to `"stdio"` when missing/null/empty
- **Benefits**: Simpler configs, graceful handling of invalid entries, backward compatible

### 2. Enhanced CLI help for default run mode  
- **Problem**: Users didn't know they could use MCP flags directly without `mcp run`
- **Solution**: Show MCP options and examples in main help, hide deprecated flags
- **Benefits**: Better discoverability, cleaner help output, preserved functionality

## Test Plan
- [x] All existing tests pass (44/44 config parser tests)
- [x] Full test suite passes (508 tests) 
- [x] MCP configs without `type` field work correctly
- [x] CLI help shows MCP options and examples
- [x] Hidden deprecated options still work internally
- [x] Default run mode auto-insertion still works

🤖 Generated with [Claude Code](https://claude.ai/code)