### PR TITLE
docs: add Bun installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ Replace your `.mcp.json` with:
 }
 ```
 
+> **Using Bun?** If you have [Bun](https://bun.com/docs/cli/install) installed, you can use `bunx` instead of `npx`:
+>
+> ```json
+> {
+>   "mcpServers": {
+>     "hypertool": {
+>       "command": "bunx",
+>       "args": ["@toolprint/hypertool-mcp", "--mcp-config", ".mcp.hypertool.json"]
+>     }
+>   }
+> }
+> ```
+
 ### Step 3: Create Your First Toolset
 Restart your AI and try:
 ```


### PR DESCRIPTION
## Summary
- document bunx usage to install hypertool-mcp alongside npx
- note bun install docs

## Testing
- `npm test` *(fails: Server not built. Run 'npm run build' first.)*
- `npm test -- --reporter=dot` *(fails: Server not built. Run 'npm run build' first.)*


------
https://chatgpt.com/codex/tasks/task_b_68baff51fadc83309534e77eee8f9bf3